### PR TITLE
add missing import

### DIFF
--- a/reconstruct_osteosarcoma.ipynb
+++ b/reconstruct_osteosarcoma.ipynb
@@ -12,7 +12,7 @@
     "import altair as alt\n",
     "import novosparc\n",
     "import random \n",
-    "\n",
+    "import os\n",
     "random.seed(20)"
    ]
   },


### PR DESCRIPTION
I noticed then when running the osteosarcoma notebook one of the cells didn't run as a result of the missing 'os' import